### PR TITLE
Second condition is redundant

### DIFF
--- a/zss/compare.py
+++ b/zss/compare.py
@@ -120,8 +120,7 @@ def distance(A, B):
             for y in xrange(Bl[j], j+1):
                 # only need to check if x is an ancestor of i
                 # and y is an ancestor of j
-                if (A.lmds[i] == A.lmds[x] and B.lmds[j] == B.lmds[y] or
-                  (x == i and y == j)):
+                if A.lmds[i] == A.lmds[x] and B.lmds[j] == B.lmds[y]:
                     #                   +-
                     #                   | δ(l(i1)..i-1, l(j1)..j) + γ(v → λ)
                     # δ(F1 , F2 ) = min-+ δ(l(i1)..i , l(j1)..j-1) + γ(λ → w)


### PR DESCRIPTION
Hi Tim,

I was looking for a tree-diff algorithm, and I found your project. I've reviewed it for learning purposes, and if I understood the algorithm correctly, the second condition of the shared root case is always true if the first is true:

```
             if (A.lmds[i] == A.lmds[x] and B.lmds[j] == B.lmds[y] or
              (x == i and y == j)):
```

but:

 (x == i and y == j) ---> A.lmds[i] == A.lmds[x] and B.lmds[j] == B.lmds[y] 

In case I didn't understand your code properly, I'm sorry for the inconvenience. Thank you for your making your code available!
