### PR TITLE
Python 3.x and Python 2.7 cross version support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.swp
 env
 .swork.activate
+env3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nose>=1.1.2
 numpy>=1.7
+six>=1.8
 -e hg+https://code.google.com/p/py-editdist/#egg=editdist

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name='zss',
       author_email='tim.tadh@gmail.com',
       url='https://www.github.com/timtadh/zss',
       packages=['zss'],
-      requires=['editdist', 'numpy']
+      requires=['editdist', 'numpy', 'six']
 )

--- a/zss/__init__.py
+++ b/zss/__init__.py
@@ -1,8 +1,8 @@
-from compare import (
+from .compare import (
     distance,
     simple_distance,
 )
-from simple_tree import Node
+from .simple_tree import Node
 
 __all__ = ['distance', 'simple_distance', 'Node']
 __version__ = '1.1.2'

--- a/zss/__init__.py
+++ b/zss/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from .compare import (
     distance,
     simple_distance,

--- a/zss/compare.py
+++ b/zss/compare.py
@@ -12,8 +12,8 @@ try:
 except ImportError:
     def py_zeros(dim, pytype):
         assert len(dim) == 2
-        return [[pytype() for y in xrange(dim[1])]
-                for x in xrange(dim[0])]
+        return [[pytype() for y in range(dim[1])]
+                for x in range(dim[0])]
     zeros = py_zeros
 
 try:
@@ -169,13 +169,13 @@ def distance(A, B, get_children, insert_cost, remove_cost, update_cost):
         ioff = Al[i] - 1
         joff = Bl[j] - 1
 
-        for x in xrange(1, m): # δ(l(i1)..i, θ) = δ(l(1i)..1-1, θ) + γ(v → λ)
+        for x in range(1, m): # δ(l(i1)..i, θ) = δ(l(1i)..1-1, θ) + γ(v → λ)
             fd[x][0] = fd[x-1][0] + remove_cost(An[x+ioff])
-        for y in xrange(1, n): # δ(θ, l(j1)..j) = δ(θ, l(j1)..j-1) + γ(λ → w)
+        for y in range(1, n): # δ(θ, l(j1)..j) = δ(θ, l(j1)..j-1) + γ(λ → w)
             fd[0][y] = fd[0][y-1] + insert_cost(Bn[y+joff])
 
-        for x in xrange(1, m): ## the plus one is for the xrange impl
-            for y in xrange(1, n):
+        for x in range(1, m): ## the plus one is for the xrange impl
+            for y in range(1, n):
                 # only need to check if x is an ancestor of i
                 # and y is an ancestor of j
                 if Al[i] == Al[x+ioff] and Bl[j] == Bl[y+joff]:

--- a/zss/compare.py
+++ b/zss/compare.py
@@ -4,6 +4,9 @@
 #Email: tim.tadh@gmail.com, steve@steveasleep.com
 #For licensing see the LICENSE file in the top level directory.
 
+from __future__ import absolute_import
+from six.moves import range
+
 import collections
 
 try:

--- a/zss/simple_tree.py
+++ b/zss/simple_tree.py
@@ -72,12 +72,12 @@ class Node(object):
         elif not isinstance(b, str) and self.label == b.label: return 1
         elif (isinstance(b, str) and self.label != b) or self.label != b.label:
             return sum(b in c for c in self.children)
-        raise TypeError, "Object %s is not of type str or Node" % repr(b)
+        raise TypeError("Object %s is not of type str or Node" % repr(b))
 
     def __eq__(self, b):
         if b is None: return False
         if not isinstance(b, Node):
-            raise TypeError, "Must compare against type Node"
+            raise TypeError("Must compare against type Node")
         return self.label == b.label
 
     def __ne__(self, b):

--- a/zss/simple_tree.py
+++ b/zss/simple_tree.py
@@ -4,6 +4,8 @@
 #Email: tim.tadh@gmail.com
 #For licensing see the LICENSE file in the top level directory.
 
+from __future__ import absolute_import
+
 import collections
 
 

--- a/zss/tests/test_api.py
+++ b/zss/tests/test_api.py
@@ -4,11 +4,14 @@
 #Email: tim.tadh@gmail.com
 #For licensing see the LICENSE file in the top level directory.
 
+from __future__ import absolute_import
+
 from zss import (
     distance,
     simple_distance,
     Node,
 )
+
 
 try:
     from editdist import distance as strdist

--- a/zss/tests/test_compare.py
+++ b/zss/tests/test_compare.py
@@ -4,10 +4,13 @@
 #Email: tim.tadh@gmail.com, steve@steveasleep.com
 #For licensing see the LICENSE file in the top level directory.
 
+from __future__ import absolute_import
+
 from zss import (
     compare,
     Node,
 )
+
 
 def simple_trees():
     A = (

--- a/zss/tests/test_metricspace.py
+++ b/zss/tests/test_metricspace.py
@@ -26,7 +26,7 @@ N = 3
 def product(*args, **kwds):
     # product('ABCD', 'xy') --> Ax Ay Bx By Cx Cy Dx Dy
     # product(range(2), repeat=3) --> 000 001 010 011 100 101 110 111
-    pools = map(tuple, args) * kwds.get('repeat', 1)
+    pools = list(map(tuple, args)) * kwds.get('repeat', 1)
     result = [[]]
     for pool in pools:
         result = [x+[y] for x in result for y in pool]
@@ -92,10 +92,10 @@ def randtree(depth=2, alpha='abcdefghijklmnopqrstuvwxyz', repeat=2, width=2):
     root = Node("root")
     p = [root]
     c = list()
-    for x in xrange(depth-1):
+    for x in range(depth-1):
         for y in p:
-            for z in xrange(randint(1,1+width)):
-                n = Node(labels.next())
+            for z in range(randint(1,1+width)):
+                n = Node(next(labels))
                 y.addkid(n)
                 c.append(n)
         p = c
@@ -117,21 +117,21 @@ class TestTestNode(unittest.TestCase):
 
     def test_get(self):
         root = tree1()
-        self.assertEquals(root.get("a").label, "a")
-        self.assertEquals(root.get("b").label, "b")
-        self.assertEquals(root.get("c").label, "c")
-        self.assertEquals(root.get("d").label, "d")
-        self.assertEquals(root.get("e").label, "e")
-        self.assertEquals(root.get("f").label, "f")
+        self.assertEqual(root.get("a").label, "a")
+        self.assertEqual(root.get("b").label, "b")
+        self.assertEqual(root.get("c").label, "c")
+        self.assertEqual(root.get("d").label, "d")
+        self.assertEqual(root.get("e").label, "e")
+        self.assertEqual(root.get("f").label, "f")
 
-        self.assertNotEquals(root.get("a").label, "x")
-        self.assertNotEquals(root.get("b").label, "x")
-        self.assertNotEquals(root.get("c").label, "x")
-        self.assertNotEquals(root.get("d").label, "x")
-        self.assertNotEquals(root.get("e").label, "x")
-        self.assertNotEquals(root.get("f").label, "x")
+        self.assertNotEqual(root.get("a").label, "x")
+        self.assertNotEqual(root.get("b").label, "x")
+        self.assertNotEqual(root.get("c").label, "x")
+        self.assertNotEqual(root.get("d").label, "x")
+        self.assertNotEqual(root.get("e").label, "x")
+        self.assertNotEqual(root.get("f").label, "x")
 
-        self.assertEquals(root.get("x"), None)
+        self.assertEqual(root.get("x"), None)
 
     def test_iter(self):
         root = tree1()
@@ -150,7 +150,7 @@ class TestCompare(unittest.TestCase):
             #print b
             #print '------'
             #print ab, ba
-            self.assertEquals(ab,ba)
+            self.assertEqual(ab,ba)
             self.assertTrue((ab == 0 and a is b) or a is not b)
             #break
         trees = itertools.product([tree1(), tree2(), tree3(), tree4()], repeat=3)
@@ -165,16 +165,16 @@ class TestCompare(unittest.TestCase):
         #print randtree(5, repeat=3, width=2)
 
     def test_symmetry(self):
-        trees = itertools.product((randtree(5, repeat=3, width=2) for x in xrange(N)), repeat=2)
+        trees = itertools.product((randtree(5, repeat=3, width=2) for x in range(N)), repeat=2)
         for a,b in trees:
             ab = simple_distance(a,b)
             ba = simple_distance(b,a)
             #print '-----------------------------'
             #print ab, ba
-            self.assertEquals(ab, ba)
+            self.assertEqual(ab, ba)
 
     def test_nondegenercy(self):
-        trees = itertools.product((randtree(5, repeat=3, width=2) for x in xrange(N)), repeat=2)
+        trees = itertools.product((randtree(5, repeat=3, width=2) for x in range(N)), repeat=2)
         for a,b in trees:
             d = simple_distance(a,b)
             #print '-----------------------------'
@@ -182,7 +182,7 @@ class TestCompare(unittest.TestCase):
             self.assertTrue((d == 0 and a is b) or a is not b)
 
     def test_triangle_inequality(self):
-        trees = itertools.product((randtree(5, repeat=3, width=2) for x in xrange(N)), (randtree(5, repeat=3, width=2) for x in xrange(N)), (randtree(5, repeat=3, width=2) for x in xrange(N)))
+        trees = itertools.product((randtree(5, repeat=3, width=2) for x in range(N)), (randtree(5, repeat=3, width=2) for x in range(N)), (randtree(5, repeat=3, width=2) for x in range(N)))
         for a,b,c in trees:
             #print '--------------------------------'
             ab = simple_distance(a,b)
@@ -194,7 +194,7 @@ class TestCompare(unittest.TestCase):
 
     def test_labelchange(self):
 
-        for A in (randtree(5, repeat=3, width=2) for x in xrange(N*4)):
+        for A in (randtree(5, repeat=3, width=2) for x in range(N*4)):
             B = copy.deepcopy(A)
             node = random.choice([n for n in B.iter()])
             old_label = str(node.label)

--- a/zss/tests/test_metricspace.py
+++ b/zss/tests/test_metricspace.py
@@ -4,6 +4,10 @@
 #Email: tim.tadh@gmail.com
 #For licensing see the LICENSE file in the top level directory.
 
+from __future__ import absolute_import
+from six.moves import map
+from six.moves import range
+
 import copy
 import itertools
 import os

--- a/zss/tests/test_regress.py
+++ b/zss/tests/test_regress.py
@@ -4,6 +4,9 @@
 #Email: tim.tadh@gmail.com
 #For licensing see the LICENSE file in the top level directory.
 
+from __future__ import absolute_import
+from __future__ import print_function
+
 import os
 from random import seed
 

--- a/zss/tests/test_regress.py
+++ b/zss/tests/test_regress.py
@@ -70,7 +70,7 @@ def test_simplelabelchange():
             .addkid(Node("e"))
         )
     dist = simple_distance(A,B)
-    print dist
+    print(dist)
     assert dist == 3
     #print 'distance', d
 
@@ -91,7 +91,7 @@ def test_incorrect_behavior_regression():
        )
      )
     dist = simple_distance(A, B)
-    print dist
+    print(dist)
     assert dist == 2
 
 def test_dict():


### PR DESCRIPTION
Used `modernize` and `2to3` to achieve cross support. Now pulls in six as a dependency. This pr supersedes https://github.com/timtadh/zhang-shasha/pull/26 