### PR TITLE
Return operation history

### DIFF
--- a/zss/__init__.py
+++ b/zss/__init__.py
@@ -4,8 +4,8 @@ from .compare import (
     distance,
     simple_distance,
 )
+from .compare import AnnotatedTree, Operation
 from .simple_tree import Node
 
-__all__ = ['distance', 'simple_distance', 'Node']
+__all__ = ['distance', 'simple_distance', 'Node', 'AnnotatedTree', 'Operation']
 __version__ = '1.1.4'
-

--- a/zss/compare.py
+++ b/zss/compare.py
@@ -105,6 +105,13 @@ class Operation(object):
         else:
             return '<Operation Match>'
 
+    def __eq__(self, other):
+        if other is None: return False
+        if not isinstance(other, Operation):
+            raise TypeError("Must compare against type Operation")
+        return self.type == other.type and self.arg1 == other.arg1 and \
+            self.arg2 == other.arg2
+
 
 REMOVE = Operation.remove
 INSERT = Operation.insert

--- a/zss/compare.py
+++ b/zss/compare.py
@@ -63,10 +63,8 @@ class AnnotatedTree(object):
         i = 0
         while len(pstack) > 0:
             (n, nid), anc = pstack.pop()
-            #print list(anc)
             self.nodes.append(n)
             self.ids.append(nid)
-            #print n.label, [a.label for a in anc]
             if not self.get_children(n):
                 lmd = i
                 for a in anc:
@@ -81,6 +79,37 @@ class AnnotatedTree(object):
             keyroots[lmd] = i
             i += 1
         self.keyroots = sorted(keyroots.values())
+
+
+class Operation(object):
+    """
+    Dummy class for storing edit operations
+    """
+    remove = 0
+    insert = 1
+    update = 2
+    match = 3
+
+    def __init__(self, op, arg1=None, arg2=None):
+        self.type = op
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+    def __repr__(self):
+        if self.type == self.remove:
+            return '<Operation Remove>'
+        elif self.type == self.insert:
+            return '<Operation Insert>'
+        elif self.type == self.update:
+            return '<Operation Update>'
+        else:
+            return '<Operation Match>'
+
+
+REMOVE = Operation.remove
+INSERT = Operation.insert
+UPDATE = Operation.update
+MATCH = Operation.match
 
 
 def simple_distance(A, B, get_children=Node.get_children,
@@ -122,6 +151,7 @@ def simple_distance(A, B, get_children=Node.get_children,
         insert_cost=lambda node: label_dist('', get_label(node)),
         remove_cost=lambda node: label_dist(get_label(node), ''),
         update_cost=lambda a, b: label_dist(get_label(a), get_label(b)),
+        get_label=get_label
     )
 
 
@@ -157,7 +187,10 @@ def distance(A, B, get_children, insert_cost, remove_cost, update_cost):
     :return: An integer distance [0, inf+)
     '''
     A, B = AnnotatedTree(A, get_children), AnnotatedTree(B, get_children)
-    treedists = zeros((len(A.nodes), len(B.nodes)), int)
+    size_a = len(A.nodes)
+    size_b = len(B.nodes)
+    treedists = zeros((size_a, size_b), float)
+    operations = [[[] for _ in range(size_b)] for _ in range(size_a)]
 
     def treedist(i, j):
         Al = A.lmds
@@ -167,18 +200,27 @@ def distance(A, B, get_children, insert_cost, remove_cost, update_cost):
 
         m = i - Al[i] + 2
         n = j - Bl[j] + 2
-        fd = zeros((m,n), int)
+        fd = zeros((m,n), float)
+        partial_ops = [[[] for _ in range(n)] for _ in range(m)]
 
         ioff = Al[i] - 1
         joff = Bl[j] - 1
 
         for x in range(1, m): # δ(l(i1)..i, θ) = δ(l(1i)..1-1, θ) + γ(v → λ)
-            fd[x][0] = fd[x-1][0] + remove_cost(An[x+ioff])
+            node = An[x+ioff]
+            fd[x][0] = fd[x-1][0] + remove_cost(node)
+            partial_ops[x][0].append(Operation(REMOVE, node))
         for y in range(1, n): # δ(θ, l(j1)..j) = δ(θ, l(j1)..j-1) + γ(λ → w)
-            fd[0][y] = fd[0][y-1] + insert_cost(Bn[y+joff])
+            node = Bn[y+joff]
+            fd[0][y] = fd[0][y-1] + insert_cost(node)
+            partial_ops[0][y].append(Operation(INSERT, arg2=node))
 
-        for x in range(1, m): ## the plus one is for the xrange impl
+        for x in range(1, m):  # the plus one is for the xrange impl
             for y in range(1, n):
+                # x+ioff in the fd table corresponds to the same node as x in
+                # the treedists table (same for y and y+joff)
+                node1 = An[x+ioff]
+                node2 = Bn[y+joff]
                 # only need to check if x is an ancestor of i
                 # and y is an ancestor of j
                 if Al[i] == Al[x+ioff] and Bl[j] == Bl[y+joff]:
@@ -187,11 +229,24 @@ def distance(A, B, get_children, insert_cost, remove_cost, update_cost):
                     # δ(F1 , F2 ) = min-+ δ(l(i1)..i , l(j1)..j-1) + γ(λ → w)
                     #                   | δ(l(i1)..i-1, l(j1)..j-1) + γ(v → w)
                     #                   +-
-                    fd[x][y] = min(
-                        fd[x-1][y] + remove_cost(An[x+ioff]),
-                        fd[x][y-1] + insert_cost(Bn[y+joff]),
-                        fd[x-1][y-1] + update_cost(An[x+ioff], Bn[y+joff]),
-                    )
+                    costs = [fd[x-1][y] + remove_cost(node1),
+                             fd[x][y-1] + insert_cost(node2),
+                             fd[x-1][y-1] + update_cost(node1, node2)]
+                    fd[x][y] = min(costs)
+                    min_index = costs.index(fd[x][y])
+
+                    if min_index == 0:
+                        op = Operation(REMOVE, node1)
+                        partial_ops[x][y] = partial_ops[x-1][y] + [op]
+                    elif min_index == 1:
+                        op = Operation(INSERT, arg2=node2)
+                        partial_ops[x][y] = partial_ops[x][y - 1] + [op]
+                    else:
+                        op_type = MATCH if fd[x][y] == fd[x-1][y-1] else UPDATE
+                        op = Operation(op_type, node1, node2)
+                        partial_ops[x][y] = partial_ops[x - 1][y - 1] + [op]
+
+                    operations[x + ioff][y + joff] = partial_ops[x][y]
                     treedists[x+ioff][y+joff] = fd[x][y]
                 else:
                     #                   +-
@@ -202,15 +257,23 @@ def distance(A, B, get_children, insert_cost, remove_cost, update_cost):
                     #                   +-
                     p = Al[x+ioff]-1-ioff
                     q = Bl[y+joff]-1-joff
-                    #print (p, q), (len(fd), len(fd[0]))
-                    fd[x][y] = min(
-                        fd[x-1][y] + remove_cost(An[x+ioff]),
-                        fd[x][y-1] + insert_cost(Bn[y+joff]),
-                        fd[p][q] + treedists[x+ioff][y+joff]
-                    )
+                    costs = [fd[x-1][y] + remove_cost(node1),
+                             fd[x][y-1] + insert_cost(node2),
+                             fd[p][q] + treedists[x+ioff][y+joff]]
+                    fd[x][y] = min(costs)
+                    min_index = costs.index(fd[x][y])
+                    if min_index == 0:
+                        op = Operation(REMOVE, node1)
+                        partial_ops[x][y] = partial_ops[x-1][y] + [op]
+                    elif min_index == 1:
+                        op = Operation(INSERT, arg2=node2)
+                        partial_ops[x][y] = partial_ops[x][y-1] + [op]
+                    else:
+                        partial_ops[x][y] = partial_ops[p][q] + \
+                            operations[x+ioff][y+joff]
 
     for i in A.keyroots:
         for j in B.keyroots:
-            treedist(i,j)
+            treedist(i, j)
 
-    return treedists[-1][-1]
+    return treedists[-1][-1], operations[-1][-1]

--- a/zss/compare.py
+++ b/zss/compare.py
@@ -153,7 +153,8 @@ def simple_distance(A, B, get_children=Node.get_children,
         A, B, get_children,
         insert_cost=lambda node: label_dist('', get_label(node)),
         remove_cost=lambda node: label_dist(get_label(node), ''),
-        update_cost=lambda a, b: label_dist(get_label(a), get_label(b))
+        update_cost=lambda a, b: label_dist(get_label(a), get_label(b)),
+        return_operations=return_operations
     )
 
 

--- a/zss/compare.py
+++ b/zss/compare.py
@@ -113,7 +113,7 @@ MATCH = Operation.match
 
 
 def simple_distance(A, B, get_children=Node.get_children,
-        get_label=Node.get_label, label_dist=strdist):
+        get_label=Node.get_label, label_dist=strdist, return_operations=False):
     """Computes the exact tree edit distance between trees A and B.
 
     Use this function if both of these things are true:
@@ -134,7 +134,7 @@ def simple_distance(A, B, get_children=Node.get_children,
         A function ``get_label(node) == 'node label'``.All labels are assumed
         to be strings at this time. Defaults to :py:func:`zss.Node.get_label`.
 
-    :param label_distance:
+    :param label_dist:
         A function
         ``label_distance((get_label(node1), get_label(node2)) >= 0``.
         This function should take the output of ``get_label(node)`` and return
@@ -144,18 +144,21 @@ def simple_distance(A, B, get_children=Node.get_children,
         the labels are the same. A number N represent it takes N changes to
         transform one label into the other.
 
+    :param return_operations: if True, return a tuple (cost, operations)
+        where operations is a list of the operations to transform A into B.
+
     :return: An integer distance [0, inf+)
     """
     return distance(
         A, B, get_children,
         insert_cost=lambda node: label_dist('', get_label(node)),
         remove_cost=lambda node: label_dist(get_label(node), ''),
-        update_cost=lambda a, b: label_dist(get_label(a), get_label(b)),
-        get_label=get_label
+        update_cost=lambda a, b: label_dist(get_label(a), get_label(b))
     )
 
 
-def distance(A, B, get_children, insert_cost, remove_cost, update_cost):
+def distance(A, B, get_children, insert_cost, remove_cost, update_cost,
+             return_operations=False):
     '''Computes the exact tree edit distance between trees A and B with a
     richer API than :py:func:`zss.simple_distance`.
 
@@ -183,6 +186,9 @@ def distance(A, B, get_children, insert_cost, remove_cost, update_cost):
 
     :param update_cost:
         A function ``update_cost(a, b) == cost to change a into b >= 0``.
+
+    :param return_operations: if True, return a tuple (cost, operations)
+        where operations is a list of the operations to transform A into B.
 
     :return: An integer distance [0, inf+)
     '''
@@ -276,4 +282,7 @@ def distance(A, B, get_children, insert_cost, remove_cost, update_cost):
         for j in B.keyroots:
             treedist(i, j)
 
-    return treedists[-1][-1], operations[-1][-1]
+    if return_operations:
+        return treedists[-1][-1], operations[-1][-1]
+    else:
+        return treedists[-1][-1]

--- a/zss/tests/test_operations.py
+++ b/zss/tests/test_operations.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#Author: Erick Fonseca
+#Email: erickrfonseca@gmail.com
+#For licensing see the LICENSE file in the top level directory.
+
+from __future__ import absolute_import
+
+from zss import simple_distance, Node, Operation
+
+A = (
+    Node("f")
+        .addkid(Node("d")
+                .addkid(Node("a"))
+                .addkid(Node("c")
+                        .addkid(Node("b"))))
+        .addkid(Node("e"))
+)
+B = (
+    Node("f")
+        .addkid(Node("c")
+                .addkid(Node("d")
+                        .addkid(Node("a"))
+                        .addkid(Node("b"))))
+        .addkid(Node("e"))
+)
+C = (
+    Node("a")
+        .addkid(Node("c")
+                .addkid(Node("d")
+                        .addkid(Node("b"))
+                        .addkid(Node("e"))))
+        .addkid(Node("f"))
+)
+
+
+def all_equal(list1, list2):
+    if len(list1) != len(list2):
+        return False
+
+    for item1, item2 in zip(list1, list2):
+        if item1 != item2:
+            return False
+
+    return True
+
+
+def test_ab():
+    expected_ops = [Operation(Operation.match, Node("a"), Node("a")),
+                    Operation(Operation.match, Node("b"), Node("b")),
+                    Operation(Operation.remove, Node("c"), None),
+                    Operation(Operation.match, Node("d"), Node("d")),
+                    Operation(Operation.insert, None, Node("c")),
+                    Operation(Operation.match, Node("e"), Node("e")),
+                    Operation(Operation.match, Node("f"), Node("f"))]
+    cost, ops = simple_distance(A, B, return_operations=True)
+    assert ops == expected_ops
+
+
+def test_ac():
+    expected_ops = [Operation(Operation.remove, Node("a"), None),
+                    Operation(Operation.match, Node("b"), Node("b")),
+                    Operation(Operation.insert, None, Node("e")),
+                    Operation(Operation.insert, None, Node("d")),
+                    Operation(Operation.match, Node("c"), Node("c")),
+                    Operation(Operation.remove, Node("d"), None),
+                    Operation(Operation.update, Node("e"), Node("f")),
+                    Operation(Operation.update, Node("f"), Node("a"))]
+    cost, ops = simple_distance(A, C, return_operations=True)
+    assert ops == expected_ops
+
+
+def test_bc():
+    expected_ops = [Operation(Operation.remove, Node("a"), None),
+                    Operation(Operation.match, Node("b"), Node("b")),
+                    Operation(Operation.insert, None, Node("e")),
+                    Operation(Operation.match, Node("d"), Node("d")),
+                    Operation(Operation.match, Node("c"), Node("c")),
+                    Operation(Operation.update, Node("e"), Node("f")),
+                    Operation(Operation.update, Node("f"), Node("a"))]
+    cost, ops = simple_distance(B, C, return_operations=True)
+    assert ops == expected_ops


### PR DESCRIPTION
I introduced an optional parameter `return_operations`, false by default, that makes zss.distance and zss.simple_distance return a tuple `(cost, operation_history)`. The operation history is a list of `Operation` instances, a simple class I added to `compare.py`.