### PR TITLE
New release n stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ env
 .swork.activate
 env3
 MANIFEST
+zss.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='zss',
-      version='1.1.4',
+      version='1.2.0',
       description='Tree edit distance using the Zhang Shasha algorithm',
       author='Tim Henderson',
       author_email='tim.tadh@gmail.com',

--- a/zss/__init__.py
+++ b/zss/__init__.py
@@ -8,4 +8,4 @@ from .compare import AnnotatedTree, Operation
 from .simple_tree import Node
 
 __all__ = ['distance', 'simple_distance', 'Node', 'AnnotatedTree', 'Operation']
-__version__ = '1.1.4'
+__version__ = '1.2.0'


### PR DESCRIPTION
tried using the lib. Installed from pypi. when attempting to run 

```
fd = simple_distance(ta, tb, return_operations=True)
```

I get "unexpected keyword arg." Examining src in debugger I see that the code differs from what's on github, even though both are version 1.1.4.

IMO, solution is to bump version and publish a new version of pkg. I've done all the stuff for this that I can do. Please upload new pkg version.