### PR TITLE
Test operations for removal of two siblings

### DIFF
--- a/zss/compare.py
+++ b/zss/compare.py
@@ -100,13 +100,13 @@ class Operation(object):
 
     def __repr__(self):
         if self.type == self.remove:
-            return '<Operation Remove>'
+            return '<Operation Remove: ' + self.arg1.label + '>'
         elif self.type == self.insert:
-            return '<Operation Insert>'
+            return '<Operation Insert: ' + self.arg2.label + '>'
         elif self.type == self.update:
-            return '<Operation Update>'
+            return '<Operation Update: ' + self.arg1.label + ' to ' + self.arg2.label + '>'
         else:
-            return '<Operation Match>'
+            return '<Operation Match: ' + self.arg1.label + ' to ' + self.arg2.label + '>'
 
     def __eq__(self, other):
         if other is None: return False

--- a/zss/tests/test_operations.py
+++ b/zss/tests/test_operations.py
@@ -32,7 +32,12 @@ C = (
                         .addkid(Node("e"))))
         .addkid(Node("f"))
 )
-
+D = (
+    Node("a")
+        .addkid(Node("b"))
+        .addkid(Node("c"))
+)
+E = Node("a")
 
 def all_equal(list1, list2):
     if len(list1) != len(list2):
@@ -79,4 +84,11 @@ def test_bc():
                     Operation(Operation.update, Node("e"), Node("f")),
                     Operation(Operation.update, Node("f"), Node("a"))]
     cost, ops = simple_distance(B, C, return_operations=True)
+    assert ops == expected_ops
+
+def test_de():
+    expected_ops = [Operation(Operation.remove, Node("b"), None),
+                    Operation(Operation.remove, Node("c"), None),
+                    Operation(Operation.match, Node("a"), Node("a"))]
+    cost, ops = simple_distance(D, E, return_operations=True)
     assert ops == expected_ops


### PR DESCRIPTION
This small pull requests adds a single test, checking the operation sequence from:

```
  a    to  a
  |
+-+-+
|   |
b   c
```

I would expect these edit operations:

- remove b
- remove c
- match a to a

Instead, the current implementation returns:
- remove c
- match a to a

My second commit to this branch embellishes `__repr__` for `Operation` somewhat, to clarify the `pytest` diffs.

Thanks very much for this implementation! I've also been looking at [edit-distance](https://github.com/schulzch/edit-distance-js), in JavaScript, which [addresses this issue with a backtracking step that identifies additional nodes that need insert or delete operations](https://github.com/schulzch/edit-distance-js/commit/502db635ca91f3aee7575b52afc1565c5d6d5a4c).

Best,

K